### PR TITLE
Add the possibility to comment even if there is no new issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.synaptix</groupId>
     <artifactId>sonar-gitlab-plugin</artifactId>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>SonarQube :: GitLab Plugin</name>
     <description>GitLab Plugin for Reporting</description>
     <packaging>sonar-plugin</packaging>

--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/CommitIssuePostJob.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/CommitIssuePostJob.java
@@ -61,7 +61,7 @@ public class CommitIssuePostJob implements org.sonar.api.batch.PostJob, CheckPro
 
         updateReviewComments(commentsToBeAddedByLine);
 
-        if (report.hasNewIssue()) {
+        if (report.hasNewIssue() || gitLabPluginConfiguration.commentNoIssue()) {
             commitFacade.addGlobalComment(report.formatForMarkdown());
         }
 

--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPlugin.java
@@ -39,6 +39,7 @@ public class GitLabPlugin extends SonarPlugin {
     public static final String GITLAB_IGNORE_FILE = "sonar.gitlab.ignore_file";
     public static final String GITLAB_GLOBAL_TEMPLATE = "sonar.gitlab.global_template";
     public static final String GITLAB_INLINE_TEMPLATE = "sonar.gitlab.inline_template";
+    public static final String GITLAB_COMMENT_NO_ISSUE = "sonar.gitlab.comment_no_issue";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "reporting";
@@ -58,7 +59,9 @@ public class GitLabPlugin extends SonarPlugin {
                         PropertyDefinition.builder(GITLAB_REF_NAME).name("GitLab Ref Name").description("The commit revision for which project is built.").category(CATEGORY).subCategory(SUBCATEGORY)
                                 .index(6).hidden().build(),
                         PropertyDefinition.builder(GITLAB_IGNORE_FILE).name("GitLab Ingore file").description("Ignore issues on files no modified by the commit").category(CATEGORY)
-                                .subCategory(SUBCATEGORY).type(PropertyType.BOOLEAN).defaultValue(String.valueOf(false)).index(7).hidden().build()/*,
+                                .subCategory(SUBCATEGORY).type(PropertyType.BOOLEAN).defaultValue(String.valueOf(false)).index(7).hidden().build(),
+                        PropertyDefinition.builder(GITLAB_COMMENT_NO_ISSUE).name("GitLab Comment when no new issue").description("Add a comment even when there is no new issue.").category(CATEGORY)
+                                .subCategory(SUBCATEGORY).type(PropertyType.BOOLEAN).defaultValue(String.valueOf(false)).index(8).build()/*,
                         PropertyDefinition.builder(GITLAB_GLOBAL_TEMPLATE).name("GitLab Global Template").description("Template for global comment in commit.").category(CATEGORY)
                                 .subCategory(SUBCATEGORY).type(PropertyType.TEXT).index(8).build(),
                         PropertyDefinition.builder(GITLAB_INLINE_TEMPLATE).name("GitLab Inline Template").description("Template for inline comment in commit.").category(CATEGORY)

--- a/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/synaptix/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -84,4 +84,9 @@ public class GitLabPluginConfiguration {
         return settings.getString(GitLabPlugin.GITLAB_INLINE_TEMPLATE);
     }
 
+    @CheckForNull
+    public boolean commentNoIssue() {
+        return settings.getBoolean(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE);
+    }
+
 }


### PR DESCRIPTION
When we use the plugin with a merge request, after correcting the code to remove issues, we find it disturbing to have no comment telling us that we did a good job and that there is no new issues (and so that we can eventually merge).

Those changes add a configuration allowing the plugin to create a comment even if there is no new issues.