### PR TITLE
Add deep link to the issue in SonarQube to the inline template

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Inspired by https://github.com/SonarCommunity/sonar-github
 - Disable reporting in global comments
 - Disable reporting in inline comments
 - Add support Proxy
-- Ignore certficate if auto-signed 
+- Ignore certficate if auto-signed
 - Custom global comment (Template)
 - Custom inline comment (Template)
 - Get multi SHA for comment inline all commits
@@ -69,7 +69,7 @@ For SonarQube < 5.4:
 
 - Download last version https://github.com/gabrie-allaigre/sonar-gitlab-plugin/releases/download/1.6.6/sonar-gitlab-plugin-1.6.6.jar
 - Copy file in extensions directory `SONARQUBE_HOME/extensions/plugins`
-- Restart SonarQube 
+- Restart SonarQube
 
 For SonarQube >= 5.4 and < 5.6:
 
@@ -96,7 +96,7 @@ mvn --batch-mode verify sonar:sonar -Dsonar.host.url=$SONAR_URL -Dsonar.analysis
 or for comment inline in all commits of branch:
 
 ```shell
-mvn --batch-mode verify sonar:sonar -Dsonar.host.url=$SONAR_URL -Dsonar.analysis.mode=preview -Dsonar.gitlab.commit_sha=$(git log --pretty=format:%H origin/master..$CI_BUILD_REF | tr '\n' ',') -Dsonar.gitlab.ref_name=$CI_BUILD_REF_NAME -Dsonar.gitlab.project_id=$CI_PROJECT_ID -Dsonar.gitlab.unique_issue_per_inline=true 
+mvn --batch-mode verify sonar:sonar -Dsonar.host.url=$SONAR_URL -Dsonar.analysis.mode=preview -Dsonar.gitlab.commit_sha=$(git log --pretty=format:%H origin/master..$CI_BUILD_REF | tr '\n' ',') -Dsonar.gitlab.ref_name=$CI_BUILD_REF_NAME -Dsonar.gitlab.project_id=$CI_PROJECT_ID -Dsonar.gitlab.unique_issue_per_inline=true
 ```
 
 ## GitLab CI
@@ -128,42 +128,42 @@ sonarqube:
     - java
 ```
 
-| GitLab 8.x name | GitLab 9.x name |
-| -------- | ----------- |
-| CI_BUILD_REF | CI_COMMIT_SHA |
+| GitLab 8.x name   | GitLab 9.x name    |
+| ----------------- | ------------------ |
+| CI_BUILD_REF      | CI_COMMIT_SHA      |
 | CI_BUILD_REF_NAME | CI_COMMIT_REF_NAME |
 
 https://docs.gitlab.com/ce/ci/variables/#9-0-renaming
 
 ## Plugins properties
 
-| Variable | Comment | Type | Version |
-| -------- | ----------- | ---- | --- |
-| sonar.gitlab.url | GitLab url | Administration, Variable | >= 1.6.6 |
-| sonar.gitlab.max_global_issues | Maximum number of anomalies to be displayed in the global comment |  Administration, Variable | >= 1.6.6 |
-| sonar.gitlab.user_token | Token of the user who can make reports on the project, either global or per project |  Administration, Project, Variable | >= 1.6.6 |
-| sonar.gitlab.project_id | Project ID in GitLab or internal id or namespace + name or namespace + path or url http or ssh url or url or web | Project, Variable | >= 1.6.6 |
-| sonar.gitlab.commit_sha | SHA of the commit comment | Variable | >= 1.6.6 |
-| sonar.gitlab.ref_name | Branch name or reference of the commit | Variable | >= 1.6.6 |
-| sonar.gitlab.max_blocker_issues_gate | Max blocker issue for build failed (default 0) | Project, Variable | >= 2.0.0 |
-| sonar.gitlab.max_critical_issues_gate | Max critical issues for build failed (default 0) | Project, Variable | >= 2.0.0 |
-| sonar.gitlab.max_major_issues_gate | Max major issues for build failed (default -1 no fail) | Project, Variable | >= 2.0.0 |
-| sonar.gitlab.max_minor_issues_gate | Max minor issues for build failed (default -1 no fail) | Project, Variable | >= 2.0.0 |
-| sonar.gitlab.max_info_issues_gate | Max info issues for build failed (default -1 no fail) | Project, Variable | >= 2.0.0 |
-| sonar.gitlab.ignore_certificate | Ignore Certificate for access GitLab, use for auto-signing cert (default false) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.comment_no_issue | Add a comment even when there is no new issue (default false) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.disable_inline_comments | Disable issue reporting as inline comments (default false) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.only_issue_from_commit_file | Show issue for commit file only (default false) | Variable | >= 2.0.0 |
-| sonar.gitlab.only_issue_from_commit_line | Show issue for commit line only (default false) | Variable | >= 2.1.0 |
-| sonar.gitlab.build_init_state | State that should be the first when build commit status update is called (default pending) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.disable_global_comment | Disable global comment, report only inline (default false) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.failure_notification_mode | Notification is in current build (exit-code) or in commit status (commit-status) (default commit-status) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.global_template | Template for global comment in commit | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.ping_user | Ping the user who made an issue by @ mentioning. Only for default comment (default false) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.unique_issue_per_inline | Unique issue per inline comment (default false) | Administration, Variable | >= 2.0.0 |
-| sonar.gitlab.prefix_directory | Add prefix when create link for GitLab | Variable | >= 2.1.0 |
-| sonar.gitlab.api_version | GitLab API version (default v3) | Administration, Variable | >= 2.1.0 |
-| sonar.gitlab.all_issues | All issues new and old (default false, only new) | Administration, Variable | >= 2.1.0 |
+| Variable                                 | Comment                                                                                                          | Type                              | Version  |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------- |
+| sonar.gitlab.url                         | GitLab url                                                                                                       | Administration, Variable          | >= 1.6.6 |
+| sonar.gitlab.max_global_issues           | Maximum number of anomalies to be displayed in the global comment                                                | Administration, Variable          | >= 1.6.6 |
+| sonar.gitlab.user_token                  | Token of the user who can make reports on the project, either global or per project                              | Administration, Project, Variable | >= 1.6.6 |
+| sonar.gitlab.project_id                  | Project ID in GitLab or internal id or namespace + name or namespace + path or url http or ssh url or url or web | Project, Variable                 | >= 1.6.6 |
+| sonar.gitlab.commit_sha                  | SHA of the commit comment                                                                                        | Variable                          | >= 1.6.6 |
+| sonar.gitlab.ref_name                    | Branch name or reference of the commit                                                                           | Variable                          | >= 1.6.6 |
+| sonar.gitlab.max_blocker_issues_gate     | Max blocker issue for build failed (default 0)                                                                   | Project, Variable                 | >= 2.0.0 |
+| sonar.gitlab.max_critical_issues_gate    | Max critical issues for build failed (default 0)                                                                 | Project, Variable                 | >= 2.0.0 |
+| sonar.gitlab.max_major_issues_gate       | Max major issues for build failed (default -1 no fail)                                                           | Project, Variable                 | >= 2.0.0 |
+| sonar.gitlab.max_minor_issues_gate       | Max minor issues for build failed (default -1 no fail)                                                           | Project, Variable                 | >= 2.0.0 |
+| sonar.gitlab.max_info_issues_gate        | Max info issues for build failed (default -1 no fail)                                                            | Project, Variable                 | >= 2.0.0 |
+| sonar.gitlab.ignore_certificate          | Ignore Certificate for access GitLab, use for auto-signing cert (default false)                                  | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.comment_no_issue            | Add a comment even when there is no new issue (default false)                                                    | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.disable_inline_comments     | Disable issue reporting as inline comments (default false)                                                       | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.only_issue_from_commit_file | Show issue for commit file only (default false)                                                                  | Variable                          | >= 2.0.0 |
+| sonar.gitlab.only_issue_from_commit_line | Show issue for commit line only (default false)                                                                  | Variable                          | >= 2.1.0 |
+| sonar.gitlab.build_init_state            | State that should be the first when build commit status update is called (default pending)                       | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.disable_global_comment      | Disable global comment, report only inline (default false)                                                       | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.failure_notification_mode   | Notification is in current build (exit-code) or in commit status (commit-status) (default commit-status)         | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.global_template             | Template for global comment in commit                                                                            | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.ping_user                   | Ping the user who made an issue by @ mentioning. Only for default comment (default false)                        | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.unique_issue_per_inline     | Unique issue per inline comment (default false)                                                                  | Administration, Variable          | >= 2.0.0 |
+| sonar.gitlab.prefix_directory            | Add prefix when create link for GitLab                                                                           | Variable                          | >= 2.1.0 |
+| sonar.gitlab.api_version                 | GitLab API version (default v3)                                                                                  | Administration, Variable          | >= 2.1.0 |
+| sonar.gitlab.all_issues                  | All issues new and old (default false, only new)                                                                 | Administration, Variable          | >= 2.1.0 |
 
 - Administration : **Settings** globals in SonarQube
 - Project : **Settings** of project in SonarQube
@@ -189,65 +189,65 @@ Custom global/inline comment : Change language, change image, change order, prin
 
 Usage : `${name}`
 
-| name | type | description |
-| --- | --- | --- |
-| url | String | GitLab url |
-| projectId | String | Project ID in GitLab or internal id or namespace + name or namespace + path or url http or ssh url or url or web |
-| commitSHA | String[] | SHA of the commit comment. Get first `commitSHA[0]` |
-| refName | String | Branch name or reference of the commit |
-| maxGlobalIssues | Integer | Maximum number of anomalies to be displayed in the global comment |
-| maxBlockerIssuesGate | Integer | Max blocker issue for build failed |
-| maxCriticalIssuesGate | Integer | Max critical issue for build failed |
-| maxMajorIssuesGate | Integer | Max major issue for build failed |
-| maxMinorIssuesGate | Integer | Max minor issue for build failed |
-| maxInfoIssuesGate | Integer | Max info issue for build failed |
-| disableIssuesInline | Boolean | Disable issue reporting as inline comments |
-| disableGlobalComment | Boolean | Disable global comment, report only inline |
-| onlyIssueFromCommitFile | Boolean | Show issue for commit file only |
-| commentNoIssue | Boolean | Add a comment even when there is no new issue |
-| revision | String | Current revision |
-| author | String | Commit's author for inline |
-| lineNumber | Integer | Current line number for inline issues only |
-| BLOCKER | Severity | Blocker |
-| CRITICAL | Severity | Critical |
-| MAJOR | Severity | Major |
-| MINOR | Severity | Minor |
-| INFO | Severity | Info |
+| name                    | type     | description                                                                                                      |
+| ----------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| url                     | String   | GitLab url                                                                                                       |
+| projectId               | String   | Project ID in GitLab or internal id or namespace + name or namespace + path or url http or ssh url or url or web |
+| commitSHA               | String[] | SHA of the commit comment. Get first `commitSHA[0]`                                                              |
+| refName                 | String   | Branch name or reference of the commit                                                                           |
+| maxGlobalIssues         | Integer  | Maximum number of anomalies to be displayed in the global comment                                                |
+| maxBlockerIssuesGate    | Integer  | Max blocker issue for build failed                                                                               |
+| maxCriticalIssuesGate   | Integer  | Max critical issue for build failed                                                                              |
+| maxMajorIssuesGate      | Integer  | Max major issue for build failed                                                                                 |
+| maxMinorIssuesGate      | Integer  | Max minor issue for build failed                                                                                 |
+| maxInfoIssuesGate       | Integer  | Max info issue for build failed                                                                                  |
+| disableIssuesInline     | Boolean  | Disable issue reporting as inline comments                                                                       |
+| disableGlobalComment    | Boolean  | Disable global comment, report only inline                                                                       |
+| onlyIssueFromCommitFile | Boolean  | Show issue for commit file only                                                                                  |
+| commentNoIssue          | Boolean  | Add a comment even when there is no new issue                                                                    |
+| revision                | String   | Current revision                                                                                                 |
+| author                  | String   | Commit's author for inline                                                                                       |
+| lineNumber              | Integer  | Current line number for inline issues only                                                                       |
+| BLOCKER                 | Severity | Blocker                                                                                                          |
+| CRITICAL                | Severity | Critical                                                                                                         |
+| MAJOR                   | Severity | Major                                                                                                            |
+| MINOR                   | Severity | Minor                                                                                                            |
+| INFO                    | Severity | Info                                                                                                             |
 
 ## Functions
 
 Usage : `${name(arg1,arg2,...)}`
 
-| name | arguments | type | description |
-| --- | --- | --- | --- |
-| issueCount | none | Integer | Get new issue count |
-| issueCount | Boolean | Integer | Get new issue count if true only reported else false only not reported |
-| issueCount | Severity | Integer | Get new issue count by Severity |
-| issueCount | Boolean, Severity | Integer | Get new issue count by Severity if true only reported else false only not reported |
-| issues | none | List<Issue> | Get new issues |
-| issues | Boolean | List<Issue> | Get new issues if true only reported else false only not reported |
-| issues | Severity | List<Issue> | Get new issues by Severity |
-| issues | Boolean, Severity | List<Issue> | Get new issues by Severity if true only reported else false only not reported |
-| print | Issue | String | Print a issue line (same default template) |
-| emojiSeverity | Severity | String | Print a emoji by severity |
-| imageSeverity | Severity | String | Print a image by severity |
-| ruleLink | String | String | Get URL for rule in SonarQube |
+| name          | arguments         | type        | description                                                                        |
+| ------------- | ----------------- | ----------- | ---------------------------------------------------------------------------------- |
+| issueCount    | none              | Integer     | Get new issue count                                                                |
+| issueCount    | Boolean           | Integer     | Get new issue count if true only reported else false only not reported             |
+| issueCount    | Severity          | Integer     | Get new issue count by Severity                                                    |
+| issueCount    | Boolean, Severity | Integer     | Get new issue count by Severity if true only reported else false only not reported |
+| issues        | none              | List<Issue> | Get new issues                                                                     |
+| issues        | Boolean           | List<Issue> | Get new issues if true only reported else false only not reported                  |
+| issues        | Severity          | List<Issue> | Get new issues by Severity                                                         |
+| issues        | Boolean, Severity | List<Issue> | Get new issues by Severity if true only reported else false only not reported      |
+| print         | Issue             | String      | Print a issue line (same default template)                                         |
+| emojiSeverity | Severity          | String      | Print a emoji by severity                                                          |
+| imageSeverity | Severity          | String      | Print a image by severity                                                          |
+| ruleLink      | String            | String      | Get URL for rule in SonarQube                                                      |
 
-### Type 
+### Type
 
 Usage : `${Issue.name}`
 
-| name | type | description |
-| --- | --- | --- |
-| reportedOnDiff | Boolean | Reported inline |
-| url | String | URL of file/line in GitLab |
-| componentKey | String | Component key |
-| severity | Severity | Severity of issue |
-| line | Integer | Line (maybe null) |
-| key | String | Key |
-| message | String | Message (maybe null) |
-| ruleKey | String | Rule key on SonarQube |
-| new | Boolean | New issue |
+| name           | type     | description                |
+| -------------- | -------- | -------------------------- |
+| reportedOnDiff | Boolean  | Reported inline            |
+| url            | String   | URL of file/line in GitLab |
+| componentKey   | String   | Component key              |
+| severity       | Severity | Severity of issue          |
+| line           | Integer  | Line (maybe null)          |
+| key            | String   | Key                        |
+| message        | String   | Message (maybe null)       |
+| ruleKey        | String   | Rule key on SonarQube      |
+| new            | Boolean  | New issue                  |
 
 ## Examples
 
@@ -324,7 +324,7 @@ Note: The following issues were found on lines that were not modified in the com
 <@p issue=issue/>
 </#list>
 <#macro p issue>
-${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [Resolve in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
+${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [View in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
 </#macro>
 ```
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Note: The following issues were found on lines that were not modified in the com
 <@p issue=issue/>
 </#list>
 <#macro p issue>
-${emojiSeverity(issue.severity)} ${issue.message} [:blue_book:](${ruleLink(issue.ruleKey)})
+${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [Resolve in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
 </#macro>
 ```
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitIssuePostJobTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitIssuePostJobTest.java
@@ -440,7 +440,7 @@ public class CommitIssuePostJobTest {
                 "</#if>\n" +
                 "</#list>\n" +
                 "<#macro p issue>\n" +
-                "${emojiSeverity(issue.severity)} ${issue.message} [:blue_book:](${ruleLink(issue.ruleKey)})\n" +
+                "${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [View in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})\n" +
                 "</#macro>");
 
         DefaultInputFile inputFile1 = new DefaultInputFile("foo", "src/Foo.php");

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineTemplateTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineTemplateTest.java
@@ -40,7 +40,7 @@ public class InlineTemplateTest {
             "<@p issue=issue/>\n" +
             "</#list>\n" +
             "<#macro p issue>\n" +
-            "${emojiSeverity(issue.severity)} ${issue.message} [:blue_book:](${ruleLink(issue.ruleKey)})\n" +
+            "${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [View in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})\n" +
             "</#macro>";
 
     private Settings settings;

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineTemplateTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineTemplateTest.java
@@ -40,7 +40,7 @@ public class InlineTemplateTest {
             "<@p issue=issue/>\n" +
             "</#list>\n" +
             "<#macro p issue>\n" +
-            "${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [View in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})\n" +
+            "${emojiSeverity(issue.severity)} ${issue.message} [:blue_book:](${ruleLink(issue.ruleKey)})\n" +
             "</#macro>";
 
     private Settings settings;

--- a/templates/inline/default-image.md
+++ b/templates/inline/default-image.md
@@ -5,6 +5,6 @@
 <@p issue=issue/>
 </#list>
 <#macro p issue>
-${imageSeverity(issue.severity)} ${issue.message} [![RULE](https://github.com/gabrie-allaigre/sonar-gitlab-plugin/raw/master/images/rule.png)](${ruleLink(issue.ruleKey)})
+${imageSeverity(issue.severity)} ${issue.message} [![RULE](https://github.com/gabrie-allaigre/sonar-gitlab-plugin/raw/master/images/rule.png)](${ruleLink(issue.ruleKey)}) | [Resolve in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
 </#macro>
 ```

--- a/templates/inline/default-image.md
+++ b/templates/inline/default-image.md
@@ -5,6 +5,6 @@
 <@p issue=issue/>
 </#list>
 <#macro p issue>
-${imageSeverity(issue.severity)} ${issue.message} [![RULE](https://github.com/gabrie-allaigre/sonar-gitlab-plugin/raw/master/images/rule.png)](${ruleLink(issue.ruleKey)}) | [Resolve in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
+${imageSeverity(issue.severity)} ${issue.message} [![RULE](https://github.com/gabrie-allaigre/sonar-gitlab-plugin/raw/master/images/rule.png)](${ruleLink(issue.ruleKey)}) | [View in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
 </#macro>
 ```

--- a/templates/inline/default.md
+++ b/templates/inline/default.md
@@ -5,6 +5,6 @@
 <@p issue=issue/>
 </#list>
 <#macro p issue>
-${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [Resolve in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
+${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [View in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
 </#macro>
 ```

--- a/templates/inline/default.md
+++ b/templates/inline/default.md
@@ -5,6 +5,6 @@
 <@p issue=issue/>
 </#list>
 <#macro p issue>
-${emojiSeverity(issue.severity)} ${issue.message} [:blue_book:](${ruleLink(issue.ruleKey)})
+${emojiSeverity(issue.severity)} ${issue.message} [why?](${ruleLink(issue.ruleKey)}) | [Resolve in SonarQube](https://sonar.yourDomain.com/project/issues?id=${issue.componentKey}&issues=${issue.key}&open=${issue.key})
 </#macro>
 ```


### PR DESCRIPTION
It's very helpful to create a deep-link from the GitLab comment on an issue (or email received by the developers) to the particular issue in SonarQube. I've composed a URL link based on the template options available. The only thing I couldn't see how to auto-generate is the URL to the sonar instance itself. Perhaps someone could contribute that later.