### PR TITLE
Support unit test sources

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -267,7 +267,10 @@ public class SonarFacade {
 
         List<Issue> res = new ArrayList<>();
         for (Issues.Issue issue : issues) {
-            Optional<Issues.Component> componentOptional = components.stream().filter(c -> c.getKey().equals(issue.getComponent()) && "FIL".equals(c.getQualifier())).findFirst();
+            Optional<Issues.Component> componentOptional = components.stream()
+                .filter(c -> "FIL".equals(c.getQualifier()))
+                .filter(c -> c.getKey().equals(issue.getComponent()))
+                .findFirst();
 
             File file = null;
             if (componentOptional.isPresent()) {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -266,10 +267,12 @@ public class SonarFacade {
 
         List<Issues.Component> components = issuesSearchWsResponse.getComponentsList();
 
+        Predicate<String> supported = ((Predicate<String>) Qualifiers.FILE::equals).or(Qualifiers.UNIT_TEST_FILE::equals);
+
         List<Issue> res = new ArrayList<>();
         for (Issues.Issue issue : issues) {
             Optional<Issues.Component> componentOptional = components.stream()
-                .filter(c -> Qualifiers.FILE.equals(c.getQualifier()))
+                .filter(c -> supported.test(c.getQualifier()))
                 .filter(c -> c.getKey().equals(issue.getComponent()))
                 .findFirst();
 

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -32,6 +32,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.Settings;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Metric;
+import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonarqube.ws.*;
@@ -268,7 +269,7 @@ public class SonarFacade {
         List<Issue> res = new ArrayList<>();
         for (Issues.Issue issue : issues) {
             Optional<Issues.Component> componentOptional = components.stream()
-                .filter(c -> "FIL".equals(c.getQualifier()))
+                .filter(c -> Qualifiers.FILE.equals(c.getQualifier()))
                 .filter(c -> c.getKey().equals(issue.getComponent()))
                 .findFirst();
 


### PR DESCRIPTION
### Issue
Issues reported for test sources are ignored since they have **UTS** qualifier. They are reported to the global comment but have no links and are just plain text. Only link to the rule is generated.
*Detailed:* this happens because no file is found for issue and **null** is passed further to generate the report.

### General
Test sources also can have issues like for rule **squid:S3415**: *Assertion arguments should be passed in the correct order*. Those who use rules like these will experience issues with plugin. 

### Solution
Use **UTS** qualifier along with **FIL** qualifier.
Unit tests are added to check whether issues with both qualifiers make it through. If SonarFacade will drop support of **UTS** then tests will report NullPointerExceptions since there will be no file assigned to the issue.
