### PR TITLE
Integration with sonar branch plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <license.mailto>gabriel.allaigre@talanlabs.com</license.mailto>
     <license.owner>Talanlabs</license.owner>
 
-    <sonar.version>5.6</sonar.version>
+    <sonar.version>6.7</sonar.version>
     <sonar.pluginName>GitLab</sonar.pluginName>
     <sonar.pluginClass>com.talanlabs.sonar.plugins.gitlab.GitLabPlugin</sonar.pluginClass>
 

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -239,7 +239,7 @@ public class SonarFacade {
         WsResponse wsResponse = wsClient.wsConnector().call(getRequest);
 
         if (wsResponse.code() != 200) {
-            throw new HttpException(wsClient.wsConnector().baseUrl() + toString(getRequest), wsResponse.code());
+            throw new HttpException(wsClient.wsConnector().baseUrl() + toString(getRequest), wsResponse.code(), wsResponse.content());
         }
 
         try {
@@ -297,7 +297,7 @@ public class SonarFacade {
         WsResponse wsResponse = wsClient.wsConnector().call(getRequest);
 
         if (wsResponse.code() != 200) {
-            throw new HttpException(wsClient.wsConnector().baseUrl() + toString(getRequest), wsResponse.code());
+            throw new HttpException(wsClient.wsConnector().baseUrl() + toString(getRequest), wsResponse.code(), wsResponse.content());
         }
 
         WsComponents.ShowWsResponse showWsResponse;
@@ -343,7 +343,7 @@ public class SonarFacade {
         WsResponse wsResponse = wsClient.wsConnector().call(getRequest);
 
         if (wsResponse.code() != 200) {
-            throw new HttpException(wsClient.wsConnector().baseUrl() + toString(getRequest), wsResponse.code());
+            throw new HttpException(wsClient.wsConnector().baseUrl() + toString(getRequest), wsResponse.code(), wsResponse.content());
         }
 
         try {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -233,7 +233,7 @@ public class SonarFacade {
 
     private Issues.SearchWsResponse searchIssues(String componentKey, String branch, int page) {
         GetRequest getRequest = new GetRequest("api/issues/search").setParam("componentKeys", componentKey).setParam("p", page).setParam("resolved", false).setMediaType(MediaTypes.PROTOBUF);
-        if (branch != null && !branch.trim().isEmpty()) {
+        if (!isBlankOrEmpty(branch)) {
             getRequest.setParam("branch", branch);
         }
         WsResponse wsResponse = wsClient.wsConnector().call(getRequest);
@@ -247,6 +247,10 @@ public class SonarFacade {
         } catch (IOException e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
+    }
+
+    private boolean isBlankOrEmpty(String branch) {
+        return branch == null || branch.trim().isEmpty();
     }
 
     private String toString(GetRequest getRequest) {

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitProjectBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitProjectBuilderTest.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 import org.sonar.api.batch.bootstrap.ProjectBuilder;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 import java.io.File;
@@ -46,7 +47,7 @@ public class CommitProjectBuilderTest {
 
     @Before
     public void prepare() {
-        settings = new Settings(new PropertyDefinitions(GitLabPlugin.definitions()));
+        settings = new MapSettings(new PropertyDefinitions(GitLabPlugin.definitions()));
         sonarFacade = mock(SonarFacade.class);
         commitFacade = mock(CommitFacade.class);
         commitProjectBuilder = new CommitProjectBuilder(new GitLabPluginConfiguration(settings, new System2()), sonarFacade, commitFacade);

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJobTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJobTest.java
@@ -36,6 +36,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.System2;
 
@@ -61,7 +62,7 @@ public class CommitPublishPostJobTest {
     @Before
     public void prepare() {
         commitFacade = Mockito.mock(CommitFacade.class);
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
         settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
@@ -32,6 +32,7 @@ import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 import java.net.Proxy;
@@ -46,7 +47,7 @@ public class GitLabPluginConfigurationTest {
 
     @Before
     public void before() {
-        settings = new Settings(new PropertyDefinitions(GitLabPlugin.definitions()));
+        settings = new MapSettings(new PropertyDefinitions(GitLabPlugin.definitions()));
         settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");
         config = new GitLabPluginConfiguration(settings, new System2());
     }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginTest.java
@@ -21,6 +21,8 @@ package com.talanlabs.sonar.plugins.gitlab;
 
 import org.junit.Test;
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarQubeSide;
+import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +31,8 @@ public class GitLabPluginTest {
 
     @Test
     public void uselessTest() {
-        Plugin.Context context = new Plugin.Context(Version.parse("5.6"));
+        final Version version = Version.parse("6.7");
+        Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(version, SonarQubeSide.SCANNER));
         new GitLabPlugin().define(context);
         assertThat(context.getExtensions().size()).isGreaterThan(7);
     }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GlobalCommentBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GlobalCommentBuilderTest.java
@@ -30,6 +30,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.System2;
 
@@ -49,7 +50,7 @@ public class GlobalCommentBuilderTest {
 
     @Before
     public void setUp() {
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GlobalTemplateTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GlobalTemplateTest.java
@@ -30,6 +30,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 import java.util.ArrayList;
@@ -110,7 +111,7 @@ public class GlobalTemplateTest {
 
     @Before
     public void setUp() {
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineCommentBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineCommentBuilderTest.java
@@ -30,6 +30,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.MessageException;
 import org.sonar.api.utils.System2;
 
@@ -50,7 +51,7 @@ public class InlineCommentBuilderTest {
 
     @Before
     public void setUp() {
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineTemplateTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/InlineTemplateTest.java
@@ -30,6 +30,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 import java.util.Collections;
@@ -50,7 +51,7 @@ public class InlineTemplateTest {
 
     @Before
     public void setUp() {
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
@@ -32,6 +32,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 import java.io.File;
@@ -57,7 +58,7 @@ public class ReporterBuilderTest {
     public void prepare() {
         sonarFacade = Mockito.mock(SonarFacade.class);
         commitFacade = Mockito.mock(CommitFacade.class);
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
         settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
@@ -28,6 +28,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 public class ReporterTest {
@@ -40,7 +41,7 @@ public class ReporterTest {
 
     @Before
     public void setup() {
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL").description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL").description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 
         settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.rule.Severity;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
@@ -60,7 +61,7 @@ public class SonarFacadeTest {
 
     @Before
     public void prepare() throws IOException {
-        settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
         settings.setProperty(CoreProperties.SERVER_BASE_URL, String.format("http://%s:%d", sonar.getHostName(), sonar.getPort()));

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
@@ -106,12 +106,12 @@ public class SonarFacadeTest {
 
     @Test
     public void testNotFound() throws IOException {
-        sonar.enqueue(new MockResponse().setResponseCode(404));
+        sonar.enqueue(new MockResponse().setResponseCode(404).setBody("Not Found"));
 
         createReportTaskFile();
 
         Assertions.assertThatThrownBy(() -> sonarFacade.loadQualityGate()).isInstanceOf(HttpException.class)
-                .hasMessage("Error 404 on http://" + sonar.getHostName() + ":" + sonar.getPort() + "/api/ce/task?id=AVz4Pj0lCGu3nUwPQk4H");
+                .hasMessage("Error 404 on http://" + sonar.getHostName() + ":" + sonar.getPort() + "/api/ce/task?id=AVz4Pj0lCGu3nUwPQk4H : Not Found");
     }
 
     @Test
@@ -201,12 +201,12 @@ public class SonarFacadeTest {
         WsCe.TaskResponse taskResponse = WsCe.TaskResponse.newBuilder().setTask(WsCe.Task.newBuilder().setStatus(WsCe.TaskStatus.SUCCESS).setAnalysisId("123456").build()).build();
         sonar.enqueue(new MockResponse().setResponseCode(200).addHeader("Content-Type", "application/x-protobuf").setBody(toBuffer(taskResponse)));
 
-        sonar.enqueue(new MockResponse().setResponseCode(404));
+        sonar.enqueue(new MockResponse().setResponseCode(404).setBody("Not Found"));
 
         createReportTaskFile();
 
         Assertions.assertThatThrownBy(() -> sonarFacade.loadQualityGate()).isInstanceOf(HttpException.class)
-                .hasMessage("Error 404 on http://" + sonar.getHostName() + ":" + sonar.getPort() + "/api/qualitygates/project_status?analysisId=123456");
+                .hasMessage("Error 404 on http://" + sonar.getHostName() + ":" + sonar.getPort() + "/api/qualitygates/project_status?analysisId=123456 : Not Found");
     }
 
     @Test
@@ -353,11 +353,11 @@ public class SonarFacadeTest {
 
     @Test
     public void tesFailed1GetNewIssue() throws IOException {
-        sonar.enqueue(new MockResponse().setResponseCode(404));
+        sonar.enqueue(new MockResponse().setResponseCode(404).setBody("Not Found"));
 
         createReportTaskFile();
         Assertions.assertThatThrownBy(() -> sonarFacade.getNewIssues()).isInstanceOf(HttpException.class)
-                .hasMessage("Error 404 on http://" + sonar.getHostName() + ":" + sonar.getPort() + "/api/issues/search?componentKeys=com.talanlabs:avatar-generator-parent&p=1&resolved=false");
+                .hasMessage("Error 404 on http://" + sonar.getHostName() + ":" + sonar.getPort() + "/api/issues/search?componentKeys=com.talanlabs:avatar-generator-parent&p=1&resolved=false : Not Found");
     }
 
     @Test

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/EmojiSeverityTemplateMethodModelExTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/EmojiSeverityTemplateMethodModelExTest.java
@@ -31,6 +31,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +42,7 @@ public class EmojiSeverityTemplateMethodModelExTest {
 
     @Before
     public void setUp() throws Exception {
-        Settings settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        Settings settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/ImageSeverityTemplateMethodModelExTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/ImageSeverityTemplateMethodModelExTest.java
@@ -31,6 +31,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +42,7 @@ public class ImageSeverityTemplateMethodModelExTest {
 
     @Before
     public void setUp() throws Exception {
-        Settings settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        Settings settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/PrintTemplateMethodModelExTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/PrintTemplateMethodModelExTest.java
@@ -31,6 +31,7 @@ import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,7 +44,7 @@ public class PrintTemplateMethodModelExTest {
 
     @Before
     public void setUp() throws Exception {
-        Settings settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        Settings settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/RuleLinkTemplateMethodModelExTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/freemarker/RuleLinkTemplateMethodModelExTest.java
@@ -30,6 +30,7 @@ import org.sonar.api.CoreProperties;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.utils.System2;
 
 import java.util.Collections;
@@ -41,7 +42,7 @@ public class RuleLinkTemplateMethodModelExTest {
 
     @Before
     public void setUp() throws Exception {
-        Settings settings = new Settings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
+        Settings settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
                 .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
                 .category(CoreProperties.CATEGORY_GENERAL).defaultValue(CoreProperties.SERVER_BASE_URL_DEFAULT_VALUE).build()).addComponents(GitLabPlugin.definitions()));
 


### PR DESCRIPTION
### Abstract
Sonar Developer Edition provides Branch Plugin to track multiple branches. This changes the behaviour of API: branch name is required in some requests. An better integration required from sonar gitlab plugin.

### Issue
If short-living branch adds new file which does not exist in upstream long-living branch then sonar gitlab plugin issues get request without specified branch, gets 404 and crashes upon it in `com.talanlabs.sonar.plugins.gitlab.SonarFacade#toFile` method. Adding `refName` from global configuration to `org.sonarqube.ws.client.component.ShowWsRequest#setBranch`, available in Sonar API 6.7, resolves the issue.

### Note
This PR is based on PR #109 .