### PR TITLE
Fixes #89: Created a new project, but do not see sonar.gitlab.user_token

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -81,7 +81,7 @@ public class GitLabPlugin implements Plugin {
                                 defaultValue(String.valueOf(false)).
                                 index(2).build(),
                         PropertyDefinition.builder(GITLAB_USER_TOKEN).name("GitLab User Token").description("GitLab user token is developer role.").category(CATEGORY).subCategory(SUBCATEGORY)
-                                .type(PropertyType.PASSWORD).index(3).build(),
+                                .type(PropertyType.PASSWORD).index(3).onQualifiers(Qualifiers.PROJECT,Qualifiers.VIEW).build(),
                         PropertyDefinition.builder(GITLAB_MAX_GLOBAL_ISSUES).name("GitLab Max Global Issues").description("Max issues to show in global comment.").category(CATEGORY)
                                 .subCategory(SUBCATEGORY).type(PropertyType.INTEGER).defaultValue(String.valueOf(10)).index(4).build(),
                         PropertyDefinition.builder(GITLAB_PROJECT_ID).name("GitLab Project id")


### PR DESCRIPTION
Change Qualifiers on  sonar.gitlab.user_token to Qualifiers.PROJECT and Qualifiers.VIEW