### PR TITLE
Gitlab codeclimate improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ https://docs.gitlab.com/ce/ci/variables/#9-0-renaming
 | sonar.gitlab.api_version | GitLab API version (default `v4` or `v3`) | Administration, Variable | >= 2.1.0 |
 | sonar.gitlab.all_issues | All issues new and old (default false, only new) | Administration, Variable | >= 2.1.0 |
 | sonar.gitlab.json_mode | Create a json report in root for GitLab EE (codeclimate.json or gl-sast-report.json) | Project, Variable | >= 3.0.0 |
+| sonar.gitlab.json_all_issues | Always report all issues in JSON report regardless of analysis mode | Project, Variable | >= 3.1.0-SNAPSHOT |
 | sonar.gitlab.query_max_retry | Max retry for wait finish analyse for publish mode | Administration, Variable | >= 3.0.0 |
 | sonar.gitlab.query_wait | Max retry for wait finish analyse for publish mode | Administration, Variable | >= 3.0.0 |
 | sonar.gitlab.quality_gate_fail_mode | Quality gate fail mode: error or warn (default error) | Administration, Variable | >= 3.0.0 |

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJob.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJob.java
@@ -66,17 +66,17 @@ public class CommitPublishPostJob implements PostJob {
     @Override
     public void execute(PostJobContext context) {
         try {
-            QualityGate qualityGate;
-            List<Issue> issues;
-            if (context.analysisMode().isPublish()) {
+            boolean publishMode = context.analysisMode().isPublish();
+
+            List<Issue> allIssues = toIssues(context.issues());
+            List<Issue> newIssues = sonarFacade.getNewIssues();
+
+            QualityGate qualityGate = null;
+            if (publishMode) {
                 qualityGate = sonarFacade.loadQualityGate();
-                issues = sonarFacade.getNewIssues();
-            } else {
-                qualityGate = null;
-                issues = toIssues(context.issues());
             }
 
-            Reporter report = reporterBuilder.build(qualityGate, issues);
+            Reporter report = reporterBuilder.build(qualityGate, allIssues, newIssues, publishMode);
             notification(report);
         } catch (MessageException e) {
             StatusNotificationsMode i = gitLabPluginConfiguration.statusNotificationsMode();

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -60,6 +60,7 @@ public class GitLabPlugin implements Plugin {
     public static final String GITLAB_API_VERSION = "sonar.gitlab.api_version";
     public static final String GITLAB_ALL_ISSUES = "sonar.gitlab.all_issues";
     public static final String GITLAB_JSON_MODE = "sonar.gitlab.json_mode";
+    public static final String GITLAB_JSON_ALL_ISSUES = "sonar.gitlab.json_all_issues";
     public static final String GITLAB_QUERY_MAX_RETRY = "sonar.gitlab.query_max_retry";
     public static final String GITLAB_QUERY_WAIT = "sonar.gitlab.query_wait";
     public static final String GITLAB_QUALITY_GATE_FAIL_MODE = "sonar.gitlab.quality_gate_fail_mode";
@@ -135,23 +136,25 @@ public class GitLabPlugin implements Plugin {
                                 .type(PropertyType.BOOLEAN).defaultValue(String.valueOf(false)).index(26).build(),
                         PropertyDefinition.builder(GITLAB_JSON_MODE).name("Generate json report").description("Create a json report in root for GitLab EE").category(CATEGORY).subCategory(SUBCATEGORY)
                                 .type(PropertyType.SINGLE_SELECT_LIST).options(JsonMode.NONE.name(), JsonMode.CODECLIMATE.name(), JsonMode.SAST.name()).defaultValue(JsonMode.NONE.name()).onlyOnQualifiers(Qualifiers.PROJECT).index(27).build(),
+                        PropertyDefinition.builder(GITLAB_JSON_ALL_ISSUES).name("JSON report all issues").description("JSON report should always report all issues").category(CATEGORY).subCategory(SUBCATEGORY)
+                                .type(PropertyType.BOOLEAN).defaultValue(Boolean.FALSE.toString()).onlyOnQualifiers(Qualifiers.PROJECT).index(28).build(),
                         PropertyDefinition.builder(GITLAB_QUERY_MAX_RETRY).name("Query max retry").description("Max retry for wait finish analyse for publish mode").category(CATEGORY).subCategory(SUBCATEGORY)
-                                .type(PropertyType.INTEGER).defaultValue(String.valueOf(50)).index(28).build(),
+                                .type(PropertyType.INTEGER).defaultValue(String.valueOf(50)).index(29).build(),
                         PropertyDefinition.builder(GITLAB_QUERY_WAIT).name("Query waiting between retry").description("Max retry for wait finish analyse for publish mode (millisecond)").category(CATEGORY).subCategory(SUBCATEGORY)
-                                .type(PropertyType.INTEGER).defaultValue(String.valueOf(1000)).index(29).build(),
+                                .type(PropertyType.INTEGER).defaultValue(String.valueOf(1000)).index(30).build(),
                         PropertyDefinition.builder(GITLAB_QUALITY_GATE_FAIL_MODE).name("Quality Gate fail mode").description("Quality gate fail mode: error or warn")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.SINGLE_SELECT_LIST)
                                 .options(QualityGateFailMode.WARN.getMeaning(), QualityGateFailMode.ERROR.getMeaning()).defaultValue(QualityGateFailMode.ERROR.getMeaning())
-                                .index(30).build(),
+                                .index(31).build(),
                         PropertyDefinition.builder(GITLAB_ISSUE_FILTER).name("Issue filter").description("Filter on issue, if MAJOR then show only MAJOR, CRITICAL and BLOCKER")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.SINGLE_SELECT_LIST)
                                 .options(Severity.INFO.name(), Severity.MINOR.name(), Severity.MAJOR.name(), Severity.CRITICAL.name(), Severity.BLOCKER.name())
                                 .defaultValue(Severity.INFO.name())
-                                .index(31).build(),
+                                .index(32).build(),
                         PropertyDefinition.builder(GITLAB_LOAD_RULES).name("Load rules information").description("Load rule for all issues")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.BOOLEAN)
                                 .defaultValue(String.valueOf(false))
-                                .index(32).build()
+                                .index(33).build()
 
                 );
     }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -193,6 +193,10 @@ public class GitLabPluginConfiguration {
         return s != null ? s : JsonMode.NONE;
     }
 
+    public boolean jsonReportAllIssues() {
+        return Boolean.valueOf(configuration.get(GitLabPlugin.GITLAB_JSON_ALL_ISSUES).orElse("false"));
+    }
+
     public int queryMaxRetry() {
         return configuration.getInt(GitLabPlugin.GITLAB_QUERY_MAX_RETRY).orElse(50);
     }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
@@ -54,13 +54,9 @@ public class Reporter {
 
     public void process(Issue issue, @Nullable Rule rule, @Nullable String revision, @Nullable String gitLabUrl, @Nullable String src, String ruleLink, boolean reportedOnDiff) {
         String r = revision != null ? revision : gitLabPluginConfiguration.commitSHA().get(0);
-        ReportIssue reportIssue = ReportIssue.newBuilder().issue(issue).rule(rule).revision(r).url(gitLabUrl).file(src).ruleLink(ruleLink).reportedOnDiff(reportedOnDiff).build();
+        ReportIssue reportIssue = getReportIssue(issue, rule, gitLabUrl, src, ruleLink, reportedOnDiff, r);
         List<ReportIssue> reportIssues = reportIssuesMap.computeIfAbsent(issue.getSeverity(), k -> new ArrayList<>());
         reportIssues.add(reportIssue);
-
-        if (!gitLabPluginConfiguration.jsonMode().equals(JsonMode.NONE)) {
-            jsonIssues.add(reportIssue);
-        }
 
         increment(issue.getSeverity());
         if (!reportedOnDiff) {
@@ -73,6 +69,25 @@ public class Reporter {
             Map<Integer, List<ReportIssue>> issuesByLine = fileLineMap.computeIfAbsent(issue.getFile(), k -> new HashMap<>());
             issuesByLine.computeIfAbsent(issue.getLine(), k -> new ArrayList<>()).add(reportIssue);
         }
+    }
+
+    public void processForJSON(Issue issue, @Nullable Rule rule, @Nullable String revision, @Nullable String gitLabUrl, @Nullable String src, String ruleLink, boolean reportedOnDiff) {
+        String r = revision != null ? revision : gitLabPluginConfiguration.commitSHA().get(0);
+        ReportIssue reportIssue = getReportIssue(issue, rule, gitLabUrl, src, ruleLink, reportedOnDiff, r);
+
+        jsonIssues.add(reportIssue);
+    }
+
+    private ReportIssue getReportIssue(Issue issue, @Nullable Rule rule, @Nullable String gitLabUrl, @Nullable String src, String ruleLink, boolean reportedOnDiff, String revision) {
+        return ReportIssue.newBuilder()
+                .issue(issue)
+                .rule(rule)
+                .revision(revision)
+                .url(gitLabUrl)
+                .file(src)
+                .ruleLink(ruleLink)
+                .reportedOnDiff(reportedOnDiff)
+                .build();
     }
 
     private void increment(Severity severity) {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
@@ -20,6 +20,7 @@
 package com.talanlabs.sonar.plugins.gitlab;
 
 import com.talanlabs.sonar.plugins.gitlab.models.*;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.sonar.api.batch.rule.Severity;
 
 import javax.annotation.Nullable;
@@ -275,6 +276,6 @@ public class Reporter {
     }
 
     private String prepareMessageJson(String message) {
-        return message.replaceAll("\"", "\\\\\"");
+        return StringEscapeUtils.escapeJson(message);
     }
 }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilder.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilder.java
@@ -85,6 +85,15 @@ public class ReporterBuilder {
         }
 
         if (!gitLabPluginConfiguration.jsonMode().equals(JsonMode.NONE)) {
+            List<Issue> jsonIssues;
+            if (!publishMode || gitLabPluginConfiguration.jsonReportAllIssues()) {
+                jsonIssues = allIssues;
+            } else {
+                jsonIssues = newIssues;
+            }
+
+            processIssuesForJSON(report, jsonIssues);
+
             String json = report.buildJson();
             commitFacade.writeJsonFile(json);
         }
@@ -97,7 +106,11 @@ public class ReporterBuilder {
     }
 
     private void processIssues(Reporter report, List<Issue> issues) {
-        getStreamIssue(issues).sorted(ISSUE_COMPARATOR).forEach(i -> processIssue(report, i));
+        getStreamIssue(issues).sorted(ISSUE_COMPARATOR).forEach(i -> processIssue(report, i, false));
+    }
+
+    private void processIssuesForJSON(Reporter report, List<Issue> issues) {
+        getStreamIssue(issues).sorted(ISSUE_COMPARATOR).forEach(i -> processIssue(report, i, true));
     }
 
     private Stream<Issue> getStreamIssue(List<Issue> issues) {
@@ -114,7 +127,7 @@ public class ReporterBuilder {
         return hasFile && issue.getLine() != null && commitFacade.getRevisionForLine(issue.getFile(), issue.getLine()) != null;
     }
 
-    private void processIssue(Reporter report, Issue issue) {
+    private void processIssue(Reporter report, Issue issue, boolean json) {
         boolean reportedInline = false;
 
         String revision = null;
@@ -135,7 +148,11 @@ public class ReporterBuilder {
                 rule = sonarFacade.getRule(issue.getRuleKey());
             }
 
-            report.process(issue, rule, revision, url, src, ruleLink, reportedInline);
+            if (json) {
+                report.processForJSON(issue, rule, revision, url, src, ruleLink, reportedInline);
+            } else {
+                report.process(issue, rule, revision, url, src, ruleLink, reportedInline);
+            }
         }
     }
 

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilder.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilder.java
@@ -60,15 +60,21 @@ public class ReporterBuilder {
      * Build a reporter for issues
      *
      * @param qualityGate Quality Gate only for publish mode
-     * @param issues      issues
+     * @param allIssues      all issues
+     * @param newIssues      new issues
+     * @param publishMode    whether or not we are executing in publish mode
      * @return a reporter
      */
-    public Reporter build(QualityGate qualityGate, List<Issue> issues) {
+    public Reporter build(QualityGate qualityGate, List<Issue> allIssues, List<Issue> newIssues, boolean publishMode) {
         Reporter report = new Reporter(gitLabPluginConfiguration);
 
         report.setQualityGate(qualityGate);
 
-        processIssues(report, issues);
+        if (publishMode) {
+            processIssues(report, newIssues);
+        } else {
+            processIssues(report, allIssues);
+        }
 
         if (gitLabPluginConfiguration.tryReportIssuesInline() && report.hasFileLine()) {
             updateReviewComments(report);

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJobTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJobTest.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
@@ -115,10 +116,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isPreview()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("success", "SonarQube reported no issues");
     }
 
@@ -134,10 +135,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isIssues()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("failed", "SonarQube reported 2 issues");
     }
 
@@ -154,10 +155,10 @@ public class CommitPublishPostJobTest {
         when(analysisMode.isPreview()).thenReturn(true);
         when(analysisMode.isIssues()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("success", "SonarQube reported no issues");
     }
 
@@ -171,10 +172,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isPreview()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("success", "SonarQube reported no issues");
     }
 
@@ -190,10 +191,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isPreview()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("failed", "SonarQube reported no issues");
     }
 
@@ -211,10 +212,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isIssues()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         Assertions.assertThatThrownBy(() -> commitPublishPostJob.execute(context)).isInstanceOf(MessageException.class).hasMessage("Report status=failed, desc=SonarQube reported 2 issues");
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("failed", "SonarQube reported 2 issues");
     }
 
@@ -230,10 +231,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isIssues()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("success", "SonarQube reported no issues");
     }
 
@@ -251,10 +252,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isIssues()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("failed", "SonarQube reported 2 issues");
     }
 
@@ -270,10 +271,10 @@ public class CommitPublishPostJobTest {
 
         when(analysisMode.isIssues()).thenReturn(true);
         when(context.issues()).thenReturn(issues);
-        when(reporterBuilder.build(eq(null), any())).thenReturn(reporter);
+        when(reporterBuilder.build(eq(null), any(), any(), anyBoolean())).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
-        Mockito.verify(reporterBuilder).build(eq(null), any());
+        Mockito.verify(reporterBuilder).build(eq(null), any(), any(), anyBoolean());
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("success", "SonarQube reported no issues");
     }
 
@@ -298,12 +299,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube Condition Error:0 Warning:0 Ok:0 SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("success", "SonarQube Condition Error:0 Warning:0 Ok:0 SonarQube reported no issues");
     }
 
@@ -326,12 +327,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("failed");
         when(reporter.getStatusDescription()).thenReturn("SonarQube Condition Error:1 Warning:2 Ok:3 SonarQube reported 2 issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:1 Warning:2 Ok:3 SonarQube reported 2 issues");
     }
 
@@ -353,12 +354,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("failed");
         when(reporter.getStatusDescription()).thenReturn("SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported 2 issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported 2 issues");
     }
 
@@ -382,12 +383,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("failed");
         when(reporter.getStatusDescription()).thenReturn("SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported 2 issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported 2 issues");
     }
 
@@ -412,12 +413,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("failed");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported 2 issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:1 Warning:2 Ok:3 SonarQube reported 2 issues");
     }
 
@@ -435,12 +436,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("success", "SonarQube Condition Error:0 Warning:0 Ok:0 SonarQube reported no issues");
     }
 
@@ -464,12 +465,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("success", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
     }
 
@@ -494,7 +495,7 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
@@ -516,12 +517,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("success", "SonarQube Condition Error:0 Warning:0 Ok:0 SonarQube reported no issues");
     }
 
@@ -545,12 +546,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("success", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
     }
 
@@ -574,12 +575,12 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("success");
         when(reporter.getStatusDescription()).thenReturn("SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         commitPublishPostJob.execute(context);
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
     }
 
@@ -604,13 +605,13 @@ public class CommitPublishPostJobTest {
         when(reporter.getStatus()).thenReturn("failed");
         when(reporter.getStatusDescription()).thenReturn("SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenReturn(reporter);
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenReturn(reporter);
 
         Assertions.assertThatThrownBy(() -> commitPublishPostJob.execute(context)).isInstanceOf(MessageException.class)
                 .hasMessage("Report status=failed, desc=SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
     }
 
@@ -632,12 +633,12 @@ public class CommitPublishPostJobTest {
         when(sonarFacade.loadQualityGate()).thenReturn(qualityGate);
 
         List<Issue> issues = Collections.emptyList();
-        when(reporterBuilder.build(qualityGate, issues)).thenThrow(new IllegalStateException("blabla"));
+        when(reporterBuilder.build(qualityGate, issues, issues, true)).thenThrow(new IllegalStateException("blabla"));
 
         Assertions.assertThatThrownBy(() -> commitPublishPostJob.execute(context)).isInstanceOf(MessageException.class).hasMessage("SonarQube failed to complete the review of this commit: blabla");
 
         Mockito.verify(sonarFacade).loadQualityGate();
-        Mockito.verify(reporterBuilder).build(qualityGate, issues);
+        Mockito.verify(reporterBuilder).build(qualityGate, issues, issues, true);
         Mockito.verify(commitFacade, never()).createOrUpdateSonarQubeStatus("failed", "SonarQube Condition Error:0 Warning:2 Ok:3 SonarQube reported no issues");
     }
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
@@ -80,7 +80,8 @@ public class ReporterBuilderTest {
     public void testCommitAnalysisNoIssue1() {
         settings.setProperty(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE, false);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.emptyList());
+        List<Issue> emptyList = Collections.emptyList();
+        Reporter reporter = reporterBuilder.build(null, emptyList, emptyList, false);
         Mockito.verify(commitFacade, Mockito.never()).addGlobalComment(null);
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("success", "SonarQube reported no issues");
     }
@@ -89,7 +90,8 @@ public class ReporterBuilderTest {
     public void testCommitAnalysisNoIssue2() {
         settings.setProperty(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE, true);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.emptyList());
+        List<Issue> emptyList = Collections.emptyList();
+        Reporter reporter = reporterBuilder.build(null, emptyList, emptyList, false);
         Mockito.verify(commitFacade).addGlobalComment("SonarQube analysis reported no issues.\n");
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("success", "SonarQube reported no issues");
     }
@@ -120,7 +122,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        Reporter reporter = reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("SonarQube analysis reported 6 issues"));
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("* :no_entry: 6 blocker"));
         Mockito.verify(commitFacade).addGlobalComment(AdditionalMatchers.not(Mockito.contains("1. [Project")));
@@ -157,7 +160,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        Reporter reporter = reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("SonarQube analysis reported 5 issues"));
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("* :no_entry: 5 blocker"));
         Mockito.verify(commitFacade).addGlobalComment(AdditionalMatchers.not(Mockito.contains("1. [Project")));
@@ -195,7 +199,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        Reporter reporter = reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("SonarQube analysis reported 1 issue"));
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("* :no_entry: 1 blocker"));
         Mockito.verify(commitFacade).addGlobalComment(AdditionalMatchers.not(Mockito.contains("1. [Project")));
@@ -224,7 +229,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 2)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Arrays.asList(newIssue1, newIssue2, newIssue3));
+        List<Issue> allIssues = Arrays.asList(newIssue1, newIssue2, newIssue3);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade).createOrUpdateReviewComment("abc123", inputFile1, 1,
                 ":no_entry: msg1 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)\n" + ":no_entry: msg2 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)");
@@ -263,7 +269,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(any(File.class))).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(any(File.class), anyInt())).thenReturn(null);
 
-        reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, newIssue4, newIssue2, issueInSecondFile, newIssue3));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, newIssue4, newIssue2, issueInSecondFile, newIssue3);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade).addGlobalComment(commentCaptor.capture());
 
@@ -280,7 +287,7 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue));
+        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue), Collections.emptyList(), false);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("failed", "SonarQube reported 1 issue, with 1 critical (fail)");
     }
@@ -294,7 +301,7 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue));
+        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue), Collections.emptyList(), false);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("success", "SonarQube reported 1 issue, with 1 major");
     }
@@ -311,7 +318,8 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        Reporter reporter = reporterBuilder.build(null, Arrays.asList(newIssue, lineNotVisible));
+        List<Issue> allIssues = Arrays.asList(newIssue, lineNotVisible);
+        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription)
                 .contains("failed", "SonarQube reported 2 issues, with 1 blocker (fail) and 1 critical (fail)");
@@ -322,7 +330,7 @@ public class ReporterBuilderTest {
         settings.setProperty(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE, false);
         settings.setProperty(GitLabPlugin.GITLAB_STATUS_NOTIFICATION_MODE, StatusNotificationsMode.EXIT_CODE.getMeaning());
 
-        reporterBuilder.build(null, Collections.emptyList());
+        reporterBuilder.build(null, Collections.emptyList(), Collections.emptyList(), false);
         Mockito.verify(commitFacade, Mockito.never()).addGlobalComment(null);
         Mockito.verify(commitFacade, Mockito.never()).createOrUpdateSonarQubeStatus("success", "SonarQube reported no issues");
     }
@@ -354,7 +362,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade, Mockito.never()).addGlobalComment(Mockito.contains("SonarQube analysis reported 6 issues"));
         Mockito.verify(commitFacade, Mockito.never()).createOrUpdateSonarQubeStatus("failed", "SonarQube reported 6 issues, with 6 blocker");
@@ -371,7 +380,7 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        reporterBuilder.build(null, Collections.singletonList(newIssue));
+        reporterBuilder.build(null, Collections.singletonList(newIssue), Collections.emptyList(), false);
 
         Mockito.verify(commitFacade, Mockito.never()).createOrUpdateSonarQubeStatus("success", "SonarQube reported 1 issue, no criticals or blockers");
     }
@@ -389,7 +398,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Arrays.asList(newIssue1, newIssue2));
+        List<Issue> allIssues = Arrays.asList(newIssue1, newIssue2);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade).createOrUpdateReviewComment("abc123", inputFile1, 1, ":no_entry: msg1 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)");
         Mockito.verify(commitFacade).createOrUpdateReviewComment("abc123", inputFile1, 1, ":no_entry: msg2 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)");
@@ -410,7 +420,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasSameCommitCommentsForFile("abc123", inputFile1, 1, ":no_entry: msg1 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)")).thenReturn(true);
         Mockito.when(commitFacade.hasSameCommitCommentsForFile("abc123", inputFile1, 1, ":no_entry: msg2 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)")).thenReturn(false);
 
-        reporterBuilder.build(null, Arrays.asList(newIssue1, newIssue2));
+        List<Issue> allIssues = Arrays.asList(newIssue1, newIssue2);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade, never()).createOrUpdateReviewComment("abc123", inputFile1, 1, ":no_entry: msg1 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)");
         Mockito.verify(commitFacade).createOrUpdateReviewComment("abc123", inputFile1, 1, ":no_entry: msg2 [:blue_book:](http://myserver/coding_rules#rule_key=repo%3Arule)");
@@ -429,7 +440,7 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Collections.singletonList(newIssue1));
+        reporterBuilder.build(null, Collections.singletonList(newIssue1), Collections.emptyList(), false);
 
         Mockito.verify(commitFacade, never()).createOrUpdateReviewComment("abc123", inputFile1, 1, "");
     }
@@ -445,7 +456,7 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Collections.singletonList(newIssue1));
+        reporterBuilder.build(null, Collections.singletonList(newIssue1), Collections.emptyList(), false);
 
         Mockito.verify(commitFacade, never()).addGlobalComment("");
     }
@@ -476,7 +487,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        Reporter reporter = reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("SonarQube analysis reported 7 issues"));
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("* :no_entry: 7 blocker"));
         Mockito.verify(commitFacade).addGlobalComment(AdditionalMatchers.not(Mockito.contains("1. [Project")));
@@ -514,7 +526,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade).writeJsonFile(Mockito.contains(
                 "[{\"tool\":\"sonarqube\",\"fingerprint\":\"null\",\"message\":\"msg\",\"file\":\"null\",\"line\":\"0\",\"priority\":\"BLOCKER\",\"solution\":\"http://myserver/coding_rules#rule_key=repo%3Arule\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"null\",\"message\":\"msg4\",\"file\":\"null\",\"line\":\"0\",\"priority\":\"BLOCKER\",\"solution\":\"http://myserver/coding_rules#rule_key=repo%3Arule\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"null\",\"message\":\"msg5\",\"file\":\"null\",\"line\":\"0\",\"priority\":\"BLOCKER\",\"solution\":\"http://myserver/coding_rules#rule_key=repo%3Arule\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"null\",\"message\":\"msg1\",\"file\":\"null\",\"line\":\"1\",\"priority\":\"BLOCKER\",\"solution\":\"http://myserver/coding_rules#rule_key=repo%3Arule\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"null\",\"message\":\"msg2\",\"file\":\"null\",\"line\":\"2\",\"priority\":\"BLOCKER\",\"solution\":\"http://myserver/coding_rules#rule_key=repo%3Arule\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"null\",\"message\":\"msg3\",\"file\":\"null\",\"line\":\"1\",\"priority\":\"BLOCKER\",\"solution\":\"http://myserver/coding_rules#rule_key=repo%3Arule\"}]"));
@@ -548,7 +561,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade).writeJsonFile(Mockito.contains(
                 "[{\"fingerprint\":\"null\",\"check_name\":\"msg\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"check_name\":\"msg4\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"check_name\":\"msg5\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"check_name\":\"msg1\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":1,\"end\":1}}},{\"fingerprint\":\"null\",\"check_name\":\"msg2\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":2,\"end\":2}}},{\"fingerprint\":\"null\",\"check_name\":\"msg3\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":1,\"end\":1}}}]"));
@@ -582,7 +596,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade, never()).writeJsonFile(any());
     }
@@ -614,7 +629,8 @@ public class ReporterBuilderTest {
         Mockito.when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         Mockito.when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn("abc123");
 
-        Reporter reporter = reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("SonarQube analysis reported 4 issues"));
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("* :no_entry: 2 blocker"));
         Mockito.verify(commitFacade).addGlobalComment(Mockito.contains("* :no_entry_sign: 2 critical"));
@@ -631,7 +647,8 @@ public class ReporterBuilderTest {
     public void testCommitAnalysisQualityGateNoIssue1() {
         settings.setProperty(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE, false);
 
-        Reporter reporter = reporterBuilder.build(QualityGate.newBuilder().status(QualityGate.Status.OK).conditions(Collections.emptyList()).build(), Collections.emptyList());
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).conditions(Collections.emptyList()).build();
+        Reporter reporter = reporterBuilder.build(qualityGate, Collections.emptyList(), Collections.emptyList(), false);
         Mockito.verify(commitFacade, Mockito.never()).addGlobalComment(null);
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("success", "SonarQube reported QualityGate is ok, with no conditions, no issues");
     }
@@ -640,7 +657,8 @@ public class ReporterBuilderTest {
     public void testCommitAnalysisQualityGateNoIssue2() {
         settings.setProperty(GitLabPlugin.GITLAB_COMMENT_NO_ISSUE, true);
 
-        Reporter reporter = reporterBuilder.build(QualityGate.newBuilder().status(QualityGate.Status.OK).conditions(Collections.emptyList()).build(), Collections.emptyList());
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).conditions(Collections.emptyList()).build();
+        Reporter reporter = reporterBuilder.build(qualityGate, Collections.emptyList(), Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment("SonarQube analysis indicates that quality gate is passed.\n\nSonarQube analysis reported no issues.\n");
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("success", "SonarQube reported QualityGate is ok, with no conditions, no issues");
     }
@@ -656,7 +674,8 @@ public class ReporterBuilderTest {
         conditions.add(QualityGate.Condition.newBuilder().status(QualityGate.Status.WARN).metricKey("toto").metricName("Toto4").actual("14").symbol(">").warning("20").error("30").build());
         conditions.add(QualityGate.Condition.newBuilder().status(QualityGate.Status.WARN).metricKey("toto").metricName("Toto5").actual("15").symbol("=").warning("10").error("").build());
 
-        Reporter reporter = reporterBuilder.build(QualityGate.newBuilder().status(QualityGate.Status.WARN).conditions(conditions).build(), Collections.emptyList());
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.WARN).conditions(conditions).build();
+        Reporter reporter = reporterBuilder.build(qualityGate, Collections.emptyList(), Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(
                 "SonarQube analysis indicates that quality gate is warning.\n" + "* Toto1 is passed: Actual value 10\n" + "* Toto2 is passed: Actual value 11\n"
                         + "* Toto3 is passed: Actual value 13\n" + "* Toto4 is warning: Actual value 14 > 20\n" + "* Toto5 is warning: Actual value 15 = 10\n" + "\n"
@@ -675,7 +694,8 @@ public class ReporterBuilderTest {
         conditions.add(QualityGate.Condition.newBuilder().status(QualityGate.Status.WARN).metricKey("toto").metricName("Toto4").actual("14").symbol(">").warning("20").error("30").build());
         conditions.add(QualityGate.Condition.newBuilder().status(QualityGate.Status.WARN).metricKey("toto").metricName("Toto5").actual("15").symbol("=").warning("10").error("").build());
 
-        Reporter reporter = reporterBuilder.build(QualityGate.newBuilder().status(QualityGate.Status.ERROR).conditions(conditions).build(), Collections.emptyList());
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.ERROR).conditions(conditions).build();
+        Reporter reporter = reporterBuilder.build(qualityGate, Collections.emptyList(), Collections.emptyList(), false);
         Mockito.verify(commitFacade).addGlobalComment(
                 "SonarQube analysis indicates that quality gate is failed.\n" + "* Toto1 is failed: Actual value 10 < 0\n" + "* Toto2 is failed: Actual value 11 >= 10\n"
                         + "* Toto3 is passed: Actual value 13\n" + "* Toto4 is warning: Actual value 14 > 20\n" + "* Toto5 is warning: Actual value 15 = 10\n" + "\n"
@@ -716,7 +736,9 @@ public class ReporterBuilderTest {
         conditions.add(QualityGate.Condition.newBuilder().status(QualityGate.Status.WARN).metricKey("toto").metricName("Toto4").actual("14").symbol(">").warning("20").error("30").build());
         conditions.add(QualityGate.Condition.newBuilder().status(QualityGate.Status.WARN).metricKey("toto").metricName("Toto5").actual("15").symbol("=").warning("10").error("").build());
 
-        Reporter reporter = reporterBuilder.build(QualityGate.newBuilder().status(QualityGate.Status.OK).conditions(conditions).build(), Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).conditions(conditions).build();
+        List<Issue> allIssues = Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue);
+        Reporter reporter = reporterBuilder.build(qualityGate, allIssues, Collections.emptyList(), false);
 
         Mockito.verify(commitFacade).addGlobalComment(
                 "SonarQube analysis indicates that quality gate is passed.\n" + "* Toto1 is failed: Actual value 10 < 0\n" + "* Toto2 is failed: Actual value 11 >= 10\n"
@@ -743,7 +765,7 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue));
+        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue), Collections.emptyList(), false);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("failed", "SonarQube reported 1 issue, with 1 critical (fail)");
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
@@ -287,7 +287,7 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue), Collections.emptyList(), false);
+        Reporter reporter = reporterBuilder.build(null, Collections.emptyList(), Collections.singletonList(newIssue), true);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("failed", "SonarQube reported 1 issue, with 1 critical (fail)");
     }
@@ -301,7 +301,7 @@ public class ReporterBuilderTest {
         when(commitFacade.hasFile(inputFile1)).thenReturn(true);
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
-        Reporter reporter = reporterBuilder.build(null, Collections.singletonList(newIssue), Collections.emptyList(), false);
+        Reporter reporter = reporterBuilder.build(null, Collections.emptyList(), Collections.singletonList(newIssue), true);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription).contains("success", "SonarQube reported 1 issue, with 1 major");
     }
@@ -319,7 +319,7 @@ public class ReporterBuilderTest {
         when(commitFacade.getRevisionForLine(inputFile1, 1)).thenReturn(null);
 
         List<Issue> allIssues = Arrays.asList(newIssue, lineNotVisible);
-        Reporter reporter = reporterBuilder.build(null, allIssues, Collections.emptyList(), false);
+        Reporter reporter = reporterBuilder.build(null, Collections.emptyList(), allIssues, true);
 
         Assertions.assertThat(reporter).isNotNull().extracting(Reporter::getStatus, Reporter::getStatusDescription)
                 .contains("failed", "SonarQube reported 2 issues, with 1 blocker (fail) and 1 critical (fail)");

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
@@ -120,7 +120,7 @@ public class ReporterTest {
     public void oneIssueSast() {
         settings.setProperty(GitLabPlugin.GITLAB_JSON_MODE, JsonMode.SAST.name());
 
-        reporter.process(Utils.newIssue("123", "component", null, 10, Severity.INFO, true, "Issue \"NULL\"", "rule"), null, null, GITLAB_URL, "file", "http://myserver", true);
+        reporter.processForJSON(Utils.newIssue("123", "component", null, 10, Severity.INFO, true, "Issue \"NULL\"", "rule"), null, null, GITLAB_URL, "file", "http://myserver", true);
 
         Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"tool\":\"sonarqube\",\"fingerprint\":\"123\",\"message\":\"Issue \\\"NULL\\\"\",\"file\":\"file\",\"line\":\"10\",\"priority\":\"INFO\",\"solution\":\"http://myserver\"}]");
     }
@@ -129,7 +129,7 @@ public class ReporterTest {
     public void oneIssueCodeClimate() {
         settings.setProperty(GitLabPlugin.GITLAB_JSON_MODE, JsonMode.CODECLIMATE.name());
 
-        reporter.process(Utils.newIssue("456", "component", null, 20, Severity.INFO, true, "Issue \"NULL\"", "rule"), null, null, GITLAB_URL, "file", "http://myserver", true);
+        reporter.processForJSON(Utils.newIssue("456", "component", null, 20, Severity.INFO, true, "Issue \"NULL\"", "rule"), null, null, GITLAB_URL, "file", "http://myserver", true);
 
         Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"fingerprint\":\"456\",\"check_name\":\"Issue \\\"NULL\\\"\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":20,\"end\":20}}}]");
     }
@@ -139,7 +139,7 @@ public class ReporterTest {
         settings.setProperty(GitLabPlugin.GITLAB_JSON_MODE, JsonMode.SAST.name());
 
         for (int i = 0; i < 5; i++) {
-            reporter.process(Utils.newIssue("toto_" + i, "component", null, null, Severity.INFO, true, "Issue", "rule" + i), null, null, GITLAB_URL, "file", "http://myserver/rule" + i, true);
+            reporter.processForJSON(Utils.newIssue("toto_" + i, "component", null, null, Severity.INFO, true, "Issue", "rule" + i), null, null, GITLAB_URL, "file", "http://myserver/rule" + i, true);
         }
 
         Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"tool\":\"sonarqube\",\"fingerprint\":\"toto_0\",\"message\":\"Issue\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule0\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"toto_1\",\"message\":\"Issue\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule1\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"toto_2\",\"message\":\"Issue\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule2\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"toto_3\",\"message\":\"Issue\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule3\"},{\"tool\":\"sonarqube\",\"fingerprint\":\"toto_4\",\"message\":\"Issue\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule4\"}]");
@@ -150,7 +150,7 @@ public class ReporterTest {
         settings.setProperty(GitLabPlugin.GITLAB_JSON_MODE, JsonMode.CODECLIMATE.name());
 
         for (int i = 0; i < 5; i++) {
-            reporter.process(Utils.newIssue("tata_" + i, "component", null, null, Severity.INFO, true, "Issue", "rule" + i), null, null, GITLAB_URL, "file", "http://myserver/rule" + i, true);
+            reporter.processForJSON(Utils.newIssue("tata_" + i, "component", null, null, Severity.INFO, true, "Issue", "rule" + i), null, null, GITLAB_URL, "file", "http://myserver/rule" + i, true);
         }
 
         Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"fingerprint\":\"tata_0\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_1\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_2\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_3\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_4\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}}]");


### PR DESCRIPTION
Hello!

I recently started using this plugin on our GitLab EE instance, and in general it works like a charm. When I configured the CodeClimate report, things were less smooth unfortunately.

On our main branch we have SonarQube running in publish mode. In publish mode, this plugin only handles issues that are reported as new by SQ. This means that in our main branch the CodeClimate file never contains all issues. In preview mode, which is being used by merge requests, all issues are correctly reported. 

GitLab compares both CodeClimate files when showing the merge request window. So when the full CodeClimate file in the merge request is compared to the near-empty one in the main branch, you can imagine the shock ;)

The goal of this merge request is to add support for writing all issues to the CodeClimate file, regardless of operating mode. I tried to do this by introducing a new property, called `sonar.gitlab.json_all_issues`. Basically all behavior is the same, except when you set that property to `true` and you run in publish mode. In that case you will get all issues in the JSON file, while still reporting only new issues as comments.

Unfortunately this required some poking around in unfamiliar code. There are a few things I'm not really proud of - for example the `Reporter.build()` method signature change to name one. Perhaps it's not all that bad, that's for the maintainers to judge ;)

Please let me know what you think!

Regards,
Martijn