### PR TITLE
Update README.md variable name #144

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ mvn --batch-mode verify sonar:sonar
       -Dsonar.host.url=http://<your_sonar_url>:9000
       -Dsonar.login=<your_sonar_login>
       -Dsonar.analysis.mode=preview
-      -Dsonar.gitlab.commit_sha=$CI_COMMIT_REF
+      -Dsonar.gitlab.commit_sha=$CI_COMMIT_SHA
       -Dsonar.gitlab.ref_name=$CI_COMMIT_REF_NAME
       -Dsonar.gitlab.project_id=$CI_PROJECT_ID
       -Dsonar.gitlab.url=http://<your_gitlab_url>


### PR DESCRIPTION
Updated the 'Make it works with a private project" selection

There was an incorrect variable name used $CI_COMMIT_REF when $CI_COMMIT_SHA is needed. 

This is related to Issue #144 