### PR TITLE
Fix #183 support new rule type in SonarQube 7.3

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/models/Rule.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/models/Rule.java
@@ -69,7 +69,8 @@ public class Rule {
 
         CODE_SMELL,
         BUG,
-        VULNERABILITY
+        VULNERABILITY,
+        SECURITY_HOTSPOT
 
     }
 


### PR DESCRIPTION
I was able to validate this change locally - adding the new enum value fixed the issue I was seeing and did not appear to affect any other rule types