### PR TITLE
Fix JSON serialization

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
@@ -20,6 +20,7 @@
 package com.talanlabs.sonar.plugins.gitlab;
 
 import com.talanlabs.sonar.plugins.gitlab.models.*;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.sonar.api.batch.rule.Severity;
 
 import javax.annotation.Nullable;
@@ -260,7 +261,6 @@ public class Reporter {
     }
 
     private String prepareMessageJson(String message) {
-        String tmp1 = message.replaceAll("\"", "\\\\\"");
-        return tmp1.replaceAll("[\n\r]"," ");
+        return StringEscapeUtils.escapeJson(message);
     }
 }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
@@ -162,6 +162,6 @@ public class ReporterTest {
 
             reporter.process(Utils.newIssue("toto", "component", null, null, Severity.INFO, true, "Issue\nline1\n\rline2", "rule"), null, null, GITLAB_URL, "file", "http://myserver/rule", true);
 
-        Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"tool\":\"sonarqube\",\"fingerprint\":\"toto\",\"message\":\"Issue line1  line2\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule\"}]");
+        Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"tool\":\"sonarqube\",\"fingerprint\":\"toto\",\"message\":\"Issue\\nline1\\n\\rline2\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule\"}]");
     }
 }


### PR DESCRIPTION
The JSON serialization could still break in certain cases, as not all escape sequences were accounted for.

I updated the `Reporter` class to use the battle-tested `StringEscapeUtils` to escape the generated JSON string. We're running the plugin internally on our SonarQube instance and so far this has solved all serialization issues.