### PR TITLE
Adding support for NONE in QualityGateFailMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ https://docs.gitlab.com/ce/ci/variables/#9-0-renaming
 | sonar.gitlab.json_mode | Create a json report in root for GitLab EE (codeclimate.json or gl-sast-report.json) | Project, Variable | >= 3.0.0 |
 | sonar.gitlab.query_max_retry | Max retry for wait finish analyse for publish mode | Administration, Variable | >= 3.0.0 |
 | sonar.gitlab.query_wait | Max retry for wait finish analyse for publish mode | Administration, Variable | >= 3.0.0 |
-| sonar.gitlab.quality_gate_fail_mode | Quality gate fail mode: error or warn (default error) | Administration, Variable | >= 3.0.0 |
+| sonar.gitlab.quality_gate_fail_mode | Quality gate fail mode: error, warn or none (default error) | Administration, Variable | >= 3.0.0 |
 | sonar.gitlab.issue_filter | Filter on issue, if MAJOR then show only MAJOR, CRITICAL and BLOCKER (default INFO) | Administration, Variable | >= 3.0.0 |
 | sonar.gitlab.load_rules | Load rules for all issues (default false) | Administration, Variable | >= 3.0.0 |
 | sonar.gitlab.disable_proxy | Disable proxy if system contains proxy config (default false) | Administration, Variable | >= 4.0.0 |

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -140,9 +140,9 @@ public class GitLabPlugin implements Plugin {
                                 .type(PropertyType.INTEGER).defaultValue(String.valueOf(50)).index(28).build(),
                         PropertyDefinition.builder(GITLAB_QUERY_WAIT).name("Query waiting between retry").description("Max retry for wait finish analyse for publish mode (millisecond)").category(CATEGORY).subCategory(SUBCATEGORY)
                                 .type(PropertyType.INTEGER).defaultValue(String.valueOf(1000)).index(29).build(),
-                        PropertyDefinition.builder(GITLAB_QUALITY_GATE_FAIL_MODE).name("Quality Gate fail mode").description("Quality gate fail mode: error or warn")
+                        PropertyDefinition.builder(GITLAB_QUALITY_GATE_FAIL_MODE).name("Quality Gate fail mode").description("Quality gate fail mode: error, warn or none")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.SINGLE_SELECT_LIST)
-                                .options(QualityGateFailMode.WARN.getMeaning(), QualityGateFailMode.ERROR.getMeaning()).defaultValue(QualityGateFailMode.ERROR.getMeaning())
+                                .options(QualityGateFailMode.NONE.getMeaning(), QualityGateFailMode.WARN.getMeaning(), QualityGateFailMode.ERROR.getMeaning()).defaultValue(QualityGateFailMode.ERROR.getMeaning())
                                 .index(30).build(),
                         PropertyDefinition.builder(GITLAB_ISSUE_FILTER).name("Issue filter").description("Filter on issue, if MAJOR then show only MAJOR, CRITICAL and BLOCKER")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.SINGLE_SELECT_LIST)

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
@@ -93,6 +93,10 @@ public class Reporter {
     }
 
     private boolean aboveQualityGate() {
+        if (QualityGateFailMode.NONE.equals(gitLabPluginConfiguration.qualityGateFailMode())) {
+            return false;
+        }
+
         return qualityGate != null && (QualityGate.Status.ERROR.equals(qualityGate.getStatus()) || (QualityGateFailMode.WARN.equals(gitLabPluginConfiguration.qualityGateFailMode())
                 && QualityGate.Status.WARN.equals(qualityGate.getStatus())));
     }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/models/QualityGateFailMode.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/models/QualityGateFailMode.java
@@ -21,7 +21,7 @@ package com.talanlabs.sonar.plugins.gitlab.models;
 
 public enum QualityGateFailMode {
 
-    ERROR("ERROR"), WARN("WARN");
+    ERROR("ERROR"), WARN("WARN"), NONE("NONE");
 
     private final String meaning;
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
@@ -132,6 +132,8 @@ public class GitLabPluginConfigurationTest {
         Assertions.assertThat(config.qualityGateFailMode()).isEqualTo(QualityGateFailMode.ERROR);
         settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.WARN.getMeaning());
         Assertions.assertThat(config.qualityGateFailMode()).isEqualTo(QualityGateFailMode.WARN);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.NONE.getMeaning());
+        Assertions.assertThat(config.qualityGateFailMode()).isEqualTo(QualityGateFailMode.NONE);
         settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, "error");
         Assertions.assertThat(config.qualityGateFailMode()).isEqualTo(QualityGateFailMode.ERROR);
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
@@ -20,6 +20,8 @@
 package com.talanlabs.sonar.plugins.gitlab;
 
 import com.talanlabs.sonar.plugins.gitlab.models.JsonMode;
+import com.talanlabs.sonar.plugins.gitlab.models.QualityGate;
+import com.talanlabs.sonar.plugins.gitlab.models.QualityGateFailMode;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -160,8 +162,112 @@ public class ReporterTest {
     public void issuesJsonLine() {
         settings.setProperty(GitLabPlugin.GITLAB_JSON_MODE, JsonMode.SAST.name());
 
-            reporter.process(Utils.newIssue("toto", "component", null, null, Severity.INFO, true, "Issue\nline1\n\rline2", "rule"), null, null, GITLAB_URL, "file", "http://myserver/rule", true);
+        reporter.process(Utils.newIssue("toto", "component", null, null, Severity.INFO, true, "Issue\nline1\n\rline2", "rule"), null, null, GITLAB_URL, "file", "http://myserver/rule", true);
 
         Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"tool\":\"sonarqube\",\"fingerprint\":\"toto\",\"message\":\"Issue\\nline1\\n\\rline2\",\"file\":\"file\",\"line\":\"0\",\"priority\":\"INFO\",\"solution\":\"http://myserver/rule\"}]");
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsNone() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).build();
+        reporter.setQualityGate(qualityGate);
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsOk() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).build();
+        reporter.setQualityGate(qualityGate);
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsWarn() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.WARN).build();
+        reporter.setQualityGate(qualityGate);
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportFailsIfQualityGateIsError() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.ERROR).build();
+        reporter.setQualityGate(qualityGate);
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.FAILED_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsNoneAndFailModeIsWarn() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.NONE).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.WARN.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsOkAndFailModeIsWarn() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.WARN.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportFailsIfQualityGateIsWarnAndFailModeIsWarn() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.WARN).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.WARN.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.FAILED_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportFailsIfQualityGateIsErrorAndFailModeIsWarn() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.ERROR).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.WARN.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.FAILED_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsNoneAndFailModeIsNone() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.NONE).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.NONE.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsOkAndFailModeIsNone() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.OK).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.NONE.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsWarnAndFailModeIsNone() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.WARN).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.NONE.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
+    }
+
+    @Test
+    public void reportSucceedsIfQualityGateIsErrorAndFailModeIsNone() {
+        QualityGate qualityGate = QualityGate.newBuilder().status(QualityGate.Status.ERROR).build();
+        reporter.setQualityGate(qualityGate);
+        settings.setProperty(GitLabPlugin.GITLAB_QUALITY_GATE_FAIL_MODE, QualityGateFailMode.NONE.getMeaning());
+
+        Assertions.assertThat(reporter.getStatus()).isEqualTo(MessageHelper.SUCCESS_GITLAB_STATUS);
     }
 }


### PR DESCRIPTION
This PR adds the support for the `NONE` option on the plugin property `sonar.gitlab.quality_gate_fail_mode`.

Using this new mode, the plugin will ignore the Quality Gate from Sonar to break the build.
This is very handy when you're using Sonarqube with Branches plugin, as the short-lived branch have only a hard-coded quality gate.

This new property allows you to customize the "Quality Gate" of your short-lived branch, by ignoring the one from Sonar and setting up your own via plugin properties `sonar.gitlab.max_*_issues_gate`.

This PR is related to Issue #204 