### PR TITLE
Code Quality Descriptions

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
@@ -229,7 +229,7 @@ public class Reporter {
 
         StringJoiner sj = new StringJoiner(",", "{", "}");
         sj.add("\"fingerprint\":\"" + issue.getKey() + "\"");
-        sj.add("\"check_name\":\"" + prepareMessageJson(issue.getMessage()) + "\"");
+        sj.add("\"description\":\"" + prepareMessageJson(issue.getMessage()) + "\"");
         sj.add("\"location\":" + buildLocationCodeQualityJson(reportIssue));
         return sj.toString();
     }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterBuilderTest.java
@@ -551,7 +551,7 @@ public class ReporterBuilderTest {
         reporterBuilder.build(null, Arrays.asList(newIssue, globalIssue, issueOnProject, issueOnDir, fileNotInPR, lineNotVisible, notNewIssue));
 
         Mockito.verify(commitFacade).writeJsonFile(Mockito.contains(
-                "[{\"fingerprint\":\"null\",\"check_name\":\"msg\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"check_name\":\"msg4\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"check_name\":\"msg5\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"check_name\":\"msg1\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":1,\"end\":1}}},{\"fingerprint\":\"null\",\"check_name\":\"msg2\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":2,\"end\":2}}},{\"fingerprint\":\"null\",\"check_name\":\"msg3\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":1,\"end\":1}}}]"));
+                "[{\"fingerprint\":\"null\",\"description\":\"msg\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"description\":\"msg4\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"description\":\"msg5\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"null\",\"description\":\"msg1\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":1,\"end\":1}}},{\"fingerprint\":\"null\",\"description\":\"msg2\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":2,\"end\":2}}},{\"fingerprint\":\"null\",\"description\":\"msg3\",\"location\":{\"path\":\"null\",\"lines\": { \"begin\":1,\"end\":1}}}]"));
     }
 
     @Test

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/ReporterTest.java
@@ -131,7 +131,7 @@ public class ReporterTest {
 
         reporter.process(Utils.newIssue("456", "component", null, 20, Severity.INFO, true, "Issue \"NULL\"", "rule"), null, null, GITLAB_URL, "file", "http://myserver", true);
 
-        Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"fingerprint\":\"456\",\"check_name\":\"Issue \\\"NULL\\\"\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":20,\"end\":20}}}]");
+        Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"fingerprint\":\"456\",\"description\":\"Issue \\\"NULL\\\"\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":20,\"end\":20}}}]");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class ReporterTest {
             reporter.process(Utils.newIssue("tata_" + i, "component", null, null, Severity.INFO, true, "Issue", "rule" + i), null, null, GITLAB_URL, "file", "http://myserver/rule" + i, true);
         }
 
-        Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"fingerprint\":\"tata_0\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_1\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_2\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_3\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_4\",\"check_name\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}}]");
+        Assertions.assertThat(reporter.buildJson()).isEqualTo("[{\"fingerprint\":\"tata_0\",\"description\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_1\",\"description\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_2\",\"description\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_3\",\"description\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}},{\"fingerprint\":\"tata_4\",\"description\":\"Issue\",\"location\":{\"path\":\"file\",\"lines\": { \"begin\":0,\"end\":0}}}]");
     }
 
     @Test


### PR DESCRIPTION
The official documentation says to use `description` instead of `check_name`.
An example error:
![image](https://user-images.githubusercontent.com/4184746/51429944-42df4c80-1be2-11e9-9ea4-8f1e5c9bc3a2.png)


See the results this has:
`check_name`:
![image](https://user-images.githubusercontent.com/4184746/51429913-fac02a00-1be1-11e9-853a-dbd3463785fb.png)

`description`:
![image](https://user-images.githubusercontent.com/4184746/51429890-9d2bdd80-1be1-11e9-935f-ae07ad5721bb.png)