### PR TITLE
Map Sonar message to CodeClimate description instead of check_name

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/Reporter.java
@@ -229,7 +229,8 @@ public class Reporter {
 
         StringJoiner sj = new StringJoiner(",", "{", "}");
         sj.add("\"fingerprint\":\"" + issue.getKey() + "\"");
-        sj.add("\"check_name\":\"" + prepareMessageJson(issue.getMessage()) + "\"");
+        sj.add("\"check_name\":\"" + reportIssue.getRuleLink() + "\"");
+        sj.add("\"description\":\"" + prepareMessageJson(issue.getMessage()) + "\"");
         sj.add("\"location\":" + buildLocationCodeQualityJson(reportIssue));
         return sj.toString();
     }


### PR DESCRIPTION
Hi,

GitLab rather explicitly state that they [ignore most of a Code Climate report](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html), and they only use the four following fields: fingerprint, location.path, location.lines.begin and location.description.

To me it feels that the `description` is what should be used to put issue.getMessage(). Moreover, the [Code Climate doc](https://developer.codeclimate.com/#get-issues) shows examples of `check_name` that really are the name of the rule being used to produce an output, and not a human-readable description of how this rule, in this specific instance, doesn't work.

So, since GitLab won't show `check_name`, and since `description` is a better match for a Sonar issue message than `check_name`, I'm submitting this request.

