### PR TITLE
Fix issues retrieval for SonarQube Community Edition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
       <version>${java-gitlab-api.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
       <version>${freemarker.version}</version>

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -193,7 +193,7 @@ public class SonarFacade {
         }
     }
 
-    private boolean isPluginInstalled(String pluginKey) {
+    public boolean isPluginInstalled(String pluginKey) {
         String response = wsClient.plugins().installed(new InstalledRequest());
         JsonElement json = new JsonParser().parse(response);
         if (json.isJsonObject()) {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -23,6 +23,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.io.Files;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.talanlabs.sonar.plugins.gitlab.models.Issue;
 import com.talanlabs.sonar.plugins.gitlab.models.QualityGate;
 import com.talanlabs.sonar.plugins.gitlab.models.Rule;
@@ -41,6 +45,7 @@ import org.sonarqube.ws.client.*;
 import org.sonarqube.ws.client.ce.TaskRequest;
 import org.sonarqube.ws.client.components.ShowRequest;
 import org.sonarqube.ws.client.issues.SearchRequest;
+import org.sonarqube.ws.client.plugins.InstalledRequest;
 import org.sonarqube.ws.client.qualitygates.ProjectStatusRequest;
 
 import java.io.File;
@@ -188,6 +193,33 @@ public class SonarFacade {
         }
     }
 
+    private boolean isPluginInstalled(String pluginKey) {
+        String response = wsClient.plugins().installed(new InstalledRequest());
+        JsonElement json = new JsonParser().parse(response);
+        if (json.isJsonObject()) {
+            JsonObject root = json.getAsJsonObject();
+            json = root.get("plugins");
+            if (json.isJsonArray()) {
+                JsonArray plugins = json.getAsJsonArray();
+                Set<String> keys = new HashSet<>();
+                plugins.forEach(j -> {
+                    if (j.isJsonObject()) {
+                        j = j.getAsJsonObject().get("key");
+                        if (j.isJsonPrimitive()) {
+                            keys.add(j.getAsString());
+                        }
+                    }
+                });
+
+                if (keys.contains(pluginKey)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     @VisibleForTesting
     String getMetricName(String metricKey) {
         try {
@@ -238,7 +270,7 @@ public class SonarFacade {
 
     private Issues.SearchWsResponse searchIssues(String componentKey, String branch, int page) {
         SearchRequest searchRequest = new SearchRequest().setComponentKeys(Collections.singletonList(componentKey)).setP(String.valueOf(page)).setResolved("false");
-        if (isNotBlankAndNotEmpty(branch)) {
+        if (isNotBlankAndNotEmpty(branch) && isPluginInstalled("branch")) {
             searchRequest.setBranch(branch);
         }
         return wsClient.issues().search(searchRequest);
@@ -292,7 +324,7 @@ public class SonarFacade {
 
     private File toFile(Issues.Component component, String branch) {
         ShowRequest showRequest = new ShowRequest().setComponent(component.getKey());
-        if (isNotBlankAndNotEmpty(branch)) {
+        if (isNotBlankAndNotEmpty(branch) && isPluginInstalled("branch")) {
             showRequest.setBranch(branch);
         }
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
@@ -537,4 +537,18 @@ public class SonarFacadeTest {
         Assertions.assertThat(sonarFacade.getMetricName("toto")).isEqualTo("toto");
         Assertions.assertThat(sonarFacade.getMetricName("security_rating")).isEqualTo("Security Rating");
     }
+
+    @Test
+    public void testIsPluginInstalled() {
+        String pluginsResponse = "{\"plugins\":[{\"key\":\"my-plugin-1\"},{\"key\":\"my-plugin-2\"}]}";
+        for (int j = 0; j < 4; j++) {
+            sonar.enqueue(new MockResponse().setResponseCode(200).addHeader("Content-Type", "application/x-protobuf").setBody(pluginsResponse));
+        }
+
+        Assertions.assertThat(sonarFacade.isPluginInstalled("my-plugin-1")).isEqualTo(true);
+        Assertions.assertThat(sonarFacade.isPluginInstalled("my-plugin-2")).isEqualTo(true);
+        Assertions.assertThat(sonarFacade.isPluginInstalled("my-plugin-3")).isEqualTo(false);
+        Assertions.assertThat(sonarFacade.isPluginInstalled(null)).isEqualTo(false);
+    }
+
 }


### PR DESCRIPTION
This pull request fixes the issue when using the Community Edition of SonarQube.

In this case the `SonarFacade.getNewIssues()` method tries to retrieve issues from the SonarQube branch defined through the `sonar.gitlab.ref_name` property, which is usually equal to the GitLab pipeline `$CI_COMMIT_REF_NAME` variable.

Branch Analysis is though part of the Developer Edition (and above), so we need to handle that specific situation in order to avoid SonarQube / GitLab mismatches.