### PR TITLE
use sonar.host.url (not sonar.core.serverBaseURL) for calling webservices

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -51,6 +51,7 @@ public class GitLabPluginConfiguration {
     private final Configuration configuration;
     private final System2 system2;
     private final String baseUrl;
+    private final String baseWsUrl;
 
     public GitLabPluginConfiguration(Configuration configuration, System2 system2) {
         super();
@@ -62,14 +63,20 @@ public class GitLabPluginConfiguration {
                 configuration.hasKey(CoreProperties.SERVER_BASE_URL) ?
                         configuration.get(CoreProperties.SERVER_BASE_URL).orElse(null) :
                         configuration.get("sonar.host.url").orElse(null);
+        this.baseUrl = sanitizeBaseUrl(tempBaseUrl);
 
+        String tempBaseWsUrl = configuration.get("sonar.host.url").orElse(null);
+        this.baseWsUrl = sanitizeBaseUrl(tempBaseWsUrl);
+    }
+
+    private static String sanitizeBaseUrl(String tempBaseUrl) {
         if (tempBaseUrl == null) {
             tempBaseUrl = "http://localhost:9000";
         }
         if (!tempBaseUrl.endsWith("/")) {
             tempBaseUrl += "/";
         }
-        this.baseUrl = tempBaseUrl;
+        return tempBaseUrl;
     }
 
     public String projectId() {
@@ -266,8 +273,19 @@ public class GitLabPluginConfiguration {
         }
     }
 
+    /**
+     * The base URL for user-facing links (usually sonar.core.serverBaseURL, when defined in the
+     * SonarQube global configuration, or sonar.host.url otherwise).
+     */
     public String baseUrl() {
         return baseUrl;
+    }
+
+    /**
+     * The base URL for calling SonarQube web-services (usually sonar.host.url).
+     */
+    public String baseWsUrl() {
+        return baseWsUrl;
     }
 
     public boolean isMergeRequestDiscussionEnabled() {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -71,7 +71,7 @@ public class SonarFacade {
     public SonarFacade(Configuration settings, GitLabPluginConfiguration gitLabPluginConfiguration) {
         this.gitLabPluginConfiguration = gitLabPluginConfiguration;
 
-        HttpConnector httpConnector = HttpConnector.newBuilder().url(gitLabPluginConfiguration.baseUrl())
+        HttpConnector httpConnector = HttpConnector.newBuilder().url(gitLabPluginConfiguration.baseWsUrl())
                 .credentials(settings.get(CoreProperties.LOGIN).orElse(null), settings.get(CoreProperties.PASSWORD).orElse(null)).build();
 
         wsClient = WsClientFactories.getDefault().newClient(httpConnector);

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
@@ -67,6 +67,15 @@ public class GitLabPluginConfigurationTest {
     }
 
     @Test
+    public void testBaseWsUrl() {
+        Assertions.assertThat(config.baseWsUrl()).isEqualTo("http://localhost:9000/");
+
+        settings.setProperty("sonar.host.url", "http://myserver2/");
+        config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
+        Assertions.assertThat(config.baseWsUrl()).isEqualTo("http://myserver2/");
+    }
+
+    @Test
     public void testGlobal() {
         Assertions.assertThat(config.url()).isEqualTo("https://gitlab.com");
         settings.setProperty(GitLabPlugin.GITLAB_URL, "https://gitlab.talanlabs.com/api");

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/SonarFacadeTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.rule.Severity;
-import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.resources.Qualifiers;
@@ -60,10 +59,9 @@ public class SonarFacadeTest {
 
     @Before
     public void prepare() throws IOException {
-        settings = new MapSettings(new PropertyDefinitions(PropertyDefinition.builder(CoreProperties.SERVER_BASE_URL).name("Server base URL")
-                .description("HTTP URL of this SonarQube server, such as <i>http://yourhost.yourdomain/sonar</i>. This value is used i.e. to create links in emails.")
-                .category(CoreProperties.CATEGORY_GENERAL).defaultValue("http://localhost:9000").build()).addComponents(GitLabPlugin.definitions()));
-        settings.setProperty(CoreProperties.SERVER_BASE_URL, String.format("http://%s:%d", sonar.getHostName(), sonar.getPort()));
+        settings = new MapSettings(new PropertyDefinitions(GitLabPlugin.definitions()));
+        settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://whatever");
+        settings.setProperty("sonar.host.url", String.format("http://%s:%d", sonar.getHostName(), sonar.getPort()));
         settings.setProperty(GitLabPlugin.GITLAB_QUERY_MAX_RETRY, 5);
 
         projectDir = temp.newFolder();


### PR DESCRIPTION
In our company, the network environment is such that the public URL of SonarQube servers (defined by the `sonar.core.serverBaseURL` property in the server config) is not the same as the internal URL which can be reached from the Gitlab-CI runners.  This is usually not an issue at all for running SQ analysis (what matters is the `sonar.host.url` property set for the SonarQube Scanner, and all webservices are called from the Gitlab-CI runners with his URL, not the public one).  But with the _sonar-gitlab-plugin_, it became an issue, because this plugin tries to use the public URL to call a webservice (to retrieve the Quality Gate status at the end of the analysis).

This patch tries to fix that: it introduces a distinction between `GitLabPluginConfiguration.baseUrl` (the public URL, to be used for user-facing links to SonarQube web pages) and `GitLabPluginConfiguration.baseWsUrl` (which is basically `sonar.host.url` or the `localhost:9000` default, thus whatever URL has actually been used for running this SonarQube analysis). The later is used in the `SonarFacade` only, and the former is still used everywhere else.